### PR TITLE
Add Test Results workflow and update test configurations

### DIFF
--- a/.github/workflows/create-test-report.yml
+++ b/.github/workflows/create-test-report.yml
@@ -1,0 +1,35 @@
+name: Test Results
+
+on:
+  workflow_run:
+    workflows: ["Build and Test .NET projects"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    permissions:
+      checks: write
+
+      # required by download step to access artifacts API
+      actions: read
+
+    steps:
+       - name: Download and Extract Artifacts
+         uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+         with:
+            run_id: ${{ github.event.workflow_run.id }}
+            path: artifacts
+
+       - name: Publish Test Results
+         uses: EnricoMi/publish-unit-test-result-action@v2
+         with:
+            commit: ${{ github.event.workflow_run.head_sha }}
+            event_file: artifacts/Event File/event.json
+            event_name: ${{ github.event.workflow_run.event }}
+            files: "artifacts/**/*.xml"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -53,15 +53,15 @@ jobs:
         run: dotnet build $SOLUTION --configuration $BUILD_CONFIG --no-restore
 
       - name: Unit Test
-        run: dotnet test --configuration $BUILD_CONFIG  --no-restore --logger "trx;LogFileName=test-results.trx" || true
+        run: dotnet test --configuration $BUILD_CONFIG --no-restore --no-build --settings runsettings.xml
 
       - name: Test Report
         uses: dorny/test-reporter@v1
         if: always()
         with:
           name: DotNET Tests
-          path: "**/test-results.trx"
-          reporter: dotnet-trx
+          path: TestResults
+          reporter: dotnet-xml
           fail-on-error: true
 
       - name: Install GitVersion
@@ -75,14 +75,14 @@ jobs:
       - run: |
           echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
 
-      # - name: Codecov
-      #   uses: codecov/codecov-action@v4.5.0
+      - name: Codecov
+        uses: codecov/codecov-action@v4.5.0
 
-      # - name: Upload dotnet test results
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: BlazorApp-test-results
-      #     path: TestResults
+      - name: Upload dotnet test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: BlazorApp-test-results
+          path: TestResults
 
         # Use always() to always run this step to
         # publish test results when there are test failures

--- a/BlazorApp.sln
+++ b/BlazorApp.sln
@@ -34,6 +34,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "4. SRC", "4. SRC", "{2A1538
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "2. Solution Items", "2. Solution Items", "{6B398A53-81D7-43B5-9442-06E78038D31B}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\create-test-report.yml = .github\workflows\create-test-report.yml
 		.github\dependabot.yml = .github\dependabot.yml
 		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
 		.github\workflows\formatting.yml = .github\workflows\formatting.yml


### PR DESCRIPTION
A new GitHub Actions workflow named `Test Results` has been added in `create-test-report.yml`. This workflow triggers on the completion of the `Build and Test .NET projects` workflow and includes steps to download artifacts and publish test results.

In `dotnet.yml`, the `Unit Test` step has been modified to use a `runsettings.xml` file for configuration and to output test results in a different format. The `Test Report` step has been updated to reflect these changes.

The `Codecov` step, which was previously commented out, has been uncommented to enable code coverage reporting.

The `Upload dotnet test results` step has been uncommented and updated to upload test results to the `TestResults` directory.

The `BlazorApp.sln` solution file has been updated to include the new `create-test-report.yml` workflow file under the `Solution Items` project.