### PR TITLE
Update GitHub Actions workflow and test reporting

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,6 +30,10 @@ jobs:
     env:
       BUILD_CONFIG: 'Release'
       SOLUTION: 'BlazorApp.sln'
+      
+    permissions:
+      checks: write
+      pull-requests: write
 
     runs-on: ubuntu-latest
 
@@ -53,16 +57,16 @@ jobs:
         run: dotnet build $SOLUTION --configuration $BUILD_CONFIG --no-restore
 
       - name: Unit Test
-        run: dotnet test --configuration $BUILD_CONFIG --no-restore --no-build --settings runsettings.xml
+        run: dotnet test --configuration $BUILD_CONFIG --no-restore --no-build --logger "trx;LogFileName=test-results.trx"
 
-      - name: Test Report
-        uses: dorny/test-reporter@v1
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          name: DotNET Tests
-          path: TestResults
-          reporter: dotnet-xml
-          fail-on-error: true
+          files: |
+            test-results/**/*.xml
+            test-results/**/*.trx
+            test-results/**/*.json
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.10.2
@@ -75,14 +79,14 @@ jobs:
       - run: |
           echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
 
-      - name: Codecov
-        uses: codecov/codecov-action@v4.5.0
+      # - name: Codecov
+      #   uses: codecov/codecov-action@v4.5.0
 
-      - name: Upload dotnet test results
-        uses: actions/upload-artifact@v4
-        with:
-          name: BlazorApp-test-results
-          path: TestResults
+      # - name: Upload dotnet test results
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: BlazorApp-test-results
+      #     path: TestResults
 
         # Use always() to always run this step to
         # publish test results when there are test failures

--- a/src/Tests/BlazorApp.Unit.Tests/BlazorApp.Unit.Tests.csproj
+++ b/src/Tests/BlazorApp.Unit.Tests/BlazorApp.Unit.Tests.csproj
@@ -30,6 +30,9 @@
 		</PackageReference>
 	</ItemGroup>
 
-
+	<PropertyGroup>
+		<VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).trx</VSTestLogger>
+		<VSTestResultsDirectory>$(MSBuildThisFileDirectory)/TestResults/$(TargetFramework)</VSTestResultsDirectory>
+	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
- Updated `dotnet.yml` to include write permissions for checks and pull-requests.
- Modified `dotnet test` command to log results in TRX format.
- Switched test reporting to `EnricoMi/publish-unit-test-result-action@v2` for TRX, XML, and JSON formats.
- Commented out Codecov and dotnet test results upload steps.
- Added properties in `BlazorApp.Unit.Tests.csproj` to configure VSTest logger for TRX output and set test results directory.