### PR TITLE
Update CI configs, refactor tests, and clean up code

### DIFF
--- a/.github/workflows/create-test-report.yml
+++ b/.github/workflows/create-test-report.yml
@@ -18,8 +18,6 @@ jobs:
 
     permissions:
       checks: write
-
-      # required by download step to access artifacts API
       actions: read
 
     steps:
@@ -30,7 +28,7 @@ jobs:
             path: artifacts
 
        - name: Publish Test Results
-         uses: EnricoMi/publish-unit-test-result-action@v2
+         uses: EnricoMi/publish-unit-test-result-action/linux@v2
          with:
             commit: ${{ github.event.workflow_run.head_sha }}
             event_file: artifacts/Event File/event.json

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -66,7 +66,7 @@ jobs:
         run: dotnet build $SOLUTION --configuration $BUILD_CONFIG --no-restore
 
       - name: Unit Test
-        run: dotnet test --configuration $BUILD_CONFIG --no-restore --no-build
+        run: dotnet test --configuration $BUILD_CONFIG --no-restore --no-build --logger trx --results-directory TestResults
 
       - name: Upload Event File
         uses: actions/upload-artifact@v4
@@ -79,8 +79,16 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Test Results
-          path: |
-            /**/Test Results/**/*.trx
+          path: TestResults
+
+      - name: Codecov
+        uses: codecov/codecov-action@v4.5.0
+
+      - name: Upload dotnet test results
+        uses: actions/upload-artifact@v4
+        with:
+          name: BlazorApp-test-results
+          path: TestResults
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v3.0.0
@@ -92,15 +100,6 @@ jobs:
         uses: gittools/actions/gitversion/execute@v3.0.0
       - run: |
           echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
-
-      # - name: Codecov
-      #   uses: codecov/codecov-action@v4.5.0
-
-      # - name: Upload dotnet test results
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: BlazorApp-test-results
-      #     path: TestResults
 
         # Use always() to always run this step to
         # publish test results when there are test failures

--- a/src/BlazorApp.Unit.Tests/BlazorApp.Unit.Tests.csproj
+++ b/src/BlazorApp.Unit.Tests/BlazorApp.Unit.Tests.csproj
@@ -30,9 +30,4 @@
 		</PackageReference>
 	</ItemGroup>
 
-	<PropertyGroup>
-		<VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).trx</VSTestLogger>
-		<VSTestResultsDirectory>$(MSBuildThisFileDirectory)/TestResults/$(TargetFramework)</VSTestResultsDirectory>
-	</PropertyGroup>
-
 </Project>


### PR DESCRIPTION
Updated `create-test-report.yml` to use `EnricoMi/publish-unit-test-result-action/linux@v2`. Enhanced `dotnet.yml` with TRX logging, simplified test results path, added `Codecov` and `Upload dotnet test results` steps, and removed commented-out steps.

Removed `VSTestLogger` and `VSTestResultsDirectory` from `BlazorApp.Unit.Tests.csproj`.

Refactored `PersistingServerAuthenticationStateProvider.cs` by removing unused `using` directives, renaming private fields, updating constructor and methods, and improving `OnPersistingAsync` method for better nullability handling.